### PR TITLE
Change from Int64 -> Int and remove deprecation warnings

### DIFF
--- a/src/FastGaussQuadrature.jl
+++ b/src/FastGaussQuadrature.jl
@@ -1,8 +1,8 @@
 module FastGaussQuadrature
    using Base
 
-export gausslegendre 
-export gausschebyshev 
+export gausslegendre
+export gausschebyshev
 export gausshermite
 export gaussjacobi
 export gausslobatto

--- a/src/gausschebyshev.jl
+++ b/src/gausschebyshev.jl
@@ -1,21 +1,21 @@
-function gausschebyshev( n::Int64, kind::Int64=1 )
-    # GAUSS-CHEBYSHEV NODES AND WEIGHTS. 
-    
+function gausschebyshev( n::Int, kind::Int=1 )
+    # GAUSS-CHEBYSHEV NODES AND WEIGHTS.
+
     # Use known explicit formulas. Complexity O(n).
-    if kind == 1 
+    if kind == 1
         # Gauss-ChebyshevT quadrature, i.e., w(x) = 1/sqrt(1-x^2)
         ([cos((2*k-1)*pi/2n) for k=n:-1:1], fill(pi./n,n))
-    elseif kind == 2 
+    elseif kind == 2
         # Gauss-ChebyshevU quadrature, i.e., w(x) = sqrt(1-x^2)
         ([cos(k*pi./(n+1)) for k=n:-1:1], [pi/(n+1)*sin(k./(n+1)*pi).^2 for k=n:-1:1])
-    elseif kind == 3 
+    elseif kind == 3
         # Gauss-ChebyshevV quadrature, i.e., w(x) = sqrt((1+x)/(1-x))
         ([cos((k-.5)*pi/(n+.5)) for k=n:-1:1], [2*pi/(n+.5)*cos((k-.5)*pi/(2(n+.5))).^2 for k=n:-1:1])
-    elseif kind == 4 
+    elseif kind == 4
         # Gauss-ChebyshevW quadrature, i.e., w(x) = sqrt((1-x)/(1+x))
         ([cos(k*pi/(n+.5)) for k=n:-1:1], [2*pi/(n+.5)*sin(k*pi/(2(n+.5))).^2 for k=n:-1:1])
-    else 
-       throw(ArgumentError("Chebyshev kind should be 1, 2, 3, or 4")) 
+    else
+       throw(ArgumentError("Chebyshev kind should be 1, 2, 3, or 4"))
     end
 end
 

--- a/src/gausshermite.jl
+++ b/src/gausshermite.jl
@@ -1,25 +1,25 @@
-function gausshermite( n::Int64 )
-# GAUSSHERMITE(n) COMPUTE THE GAUSS-HERMITE NODES AND WEIGHTS IN O(n) time. 
+function gausshermite( n::Int )
+# GAUSSHERMITE(n) COMPUTE THE GAUSS-HERMITE NODES AND WEIGHTS IN O(n) time.
 
 
-if n < 0 
-    x = (Float64[],Float64[]) 
+if n < 0
+    x = (Float64[],Float64[])
     return x
-elseif n == 0 
-    x = (Float64[],Float64[]) 
+elseif n == 0
+    x = (Float64[],Float64[])
     return x
-elseif n == 1 
+elseif n == 1
     x = ([0.0],[sqrt(pi)])
     return x
-elseif n <= 20 
+elseif n <= 20
    # GW algorithm
    x = hermpts_gw( n )
-elseif n <= 200 
+elseif n <= 200
    # REC algorithm
    x = hermpts_rec( n )
 else
    # ASY algorithm
-   x = hermpts_asy( n ) 
+   x = hermpts_asy( n )
 end
 
 if mod(n,2) == 1                              # fold out
@@ -34,7 +34,7 @@ end
 
 end
 
-function hermpts_asy( n::Int64 )
+function hermpts_asy( n::Int )
 # Compute Hermite nodes and weights using asymptotic formula
 
 x0 = HermiteInitialGuesses( n ) # get initial guesses
@@ -45,8 +45,8 @@ for k = 1:20
     val = hermpoly_asy_airy(n, theta0);
     dt = -val[1]./(sqrt(2)*sqrt(2n+1)*val[2].*sin(theta0))
     theta0 = theta0 - dt;                        # Newton update
-    if norm(dt,Inf) < sqrt(eps(Float64))/10 
-       break 
+    if norm(dt,Inf) < sqrt(eps(Float64))/10
+       break
     end
 end
 t0 = cos(theta0)
@@ -57,7 +57,7 @@ w = (exp(-x.^2)./ders.^2)';            # quadrature weights
 x = (x, w)
 end
 
-function hermpts_rec( n::Int64 )
+function hermpts_rec( n::Int )
 # Compute Hermite nodes and weights using recurrence relation.
 
 x0 = HermiteInitialGuesses( n )
@@ -68,8 +68,8 @@ for kk = 1:10
     dx = val[1]./val[2]
     dx[ isnan( dx ) ] = 0
     x0 = x0 - dx
-    if norm(dx, Inf)<sqrt(eps(Float64)) 
-        break 
+    if norm(dx, Inf)<sqrt(eps(Float64))
+        break
     end
 end
 x = x0/sqrt(2)
@@ -78,7 +78,7 @@ w = exp(-x.^2)./val[2].^2           # quadrature weights
 x = (x, w)
 end
 
-function hermpoly_rec( n::Int64, x0)
+function hermpoly_rec( n::Int, x0)
 # HERMPOLY_rec evaluation of scaled Hermite poly using recurrence
 
 # evaluate:
@@ -92,18 +92,18 @@ val = (H, (-x0.*H + sqrt(n)*Hold))
 end
 
 
-function hermpoly_asy_airy(n::Int64, theta)
+function hermpoly_asy_airy(n::Int, theta)
 # HERMPOLY_ASY evaluation hermite poly using Airy asymptotic formula in
 # theta-space.
 
 musq = 2n+1;
-cosT = cos(theta) 
+cosT = cos(theta)
 sinT = sin(theta)
 sin2T = 2*cosT.*sinT
 eta = .5*theta - .25*sin2T
 chi = -(3*eta/2).^(2/3)
 phi = (-chi./sinT.^2).^(1/4)
-C = 2*sqrt(pi)*musq^(1/6)*phi 
+C = 2*sqrt(pi)*musq^(1/6)*phi
 Airy0 = real(airy(musq.^(2/3)*chi))
 Airy1 = real(airy(1,musq.^(2/3)*chi))
 
@@ -170,7 +170,7 @@ dval = C.*dval
 val = (val, dval)
 end
 
-function HermiteInitialGuesses( n::Int64 )
+function HermiteInitialGuesses( n::Int )
 #HERMITEINTITIALGUESSES(N), Initial guesses for Hermite zeros.
 #
 # [1] L. Gatteschi, Asymptotics and bounds for the zeros of Laguerre
@@ -187,7 +187,7 @@ if mod(n,2) == 1
     a = .5
 else
     m = n>>1
-    bess = ([0:m-1]'+.5)*pi 
+    bess = ([0:m-1]'+.5)*pi
     a = -.5
 end
 nu = 4*m + 2*a + 2
@@ -207,7 +207,7 @@ airyrts_exact = [-2.338107410459762           # Exact Airy roots.
 airyrts[1:10] = airyrts_exact  # correct first 10.
 
 x_init = sqrt(abs(nu + 2^(2/3)*airyrts*nu^(1/3) + 1/5*2^(4/3)*airyrts.^2*nu^(-1/3) +
-    (11/35-a^2-12/175*airyrts.^3)/nu + (16/1575*airyrts+92/7875*airyrts.^4)*2^(2/3)*nu^(-5/3) - 
+    (11/35-a^2-12/175*airyrts.^3)/nu + (16/1575*airyrts+92/7875*airyrts.^4)*2^(2/3)*nu^(-5/3) -
     (15152/3031875*airyrts.^5+1088/121275*airyrts.^2)*2^(1/3)*nu^(-7/3)))
 x_init_airy = real(fliplr(x_init))
 
@@ -244,8 +244,8 @@ return x_init
 end
 
 
-function hermpts_gw( n::Int64 ) 
-# Golub--Welsch algorithm. Used here for n<=20. 
+function hermpts_gw( n::Int )
+# Golub--Welsch algorithm. Used here for n<=20.
 
     beta = sqrt(.5*(1:n-1))              # 3-term recurrence coeffs
     T = diagm(beta, 1) + diagm(beta, -1)   # Jacobi matrix
@@ -253,10 +253,10 @@ function hermpts_gw( n::Int64 )
     indx = sortperm(D)                  # Hermite points
     x = D[indx]
     w = sqrt(pi)*V[1,indx].^2            # weights
-    
+
     # Enforce symmetry:
-    ii = floor(Int, n/2)+1:n  
-    x = x[ii]  
+    ii = floor(Int, n/2)+1:n
+    x = x[ii]
     w = w[ii]
     return (x,w)
 end

--- a/src/gaussjacobi.jl
+++ b/src/gaussjacobi.jl
@@ -30,8 +30,8 @@ function JacobiRec(n::Int, a::Float64, b::Float64)
 #Compute nodes and weights using recurrrence relation.
     x1 = HalfRec(n, a, b, 1)
     x2 = HalfRec(n, b, a, 0)
-    x = vcat( -flipud(x2[1]) , x1[1] )
-    ders = vcat( flipud(x2[2]) , x1[2] )
+    x = vcat( -flipdim(x2[1], 1), x1[1] )
+    ders = vcat( flipdim(x2[2], 1) , x1[2] )
     w = 1./((1-x.^2).*ders.^2)
     w = 2^(a+b+1)*gamma(2+a) * gamma(2+b) / (gamma(2+a+b)*(a+1)*(b+1)) * w ./ sum(w)
     return x, w
@@ -127,7 +127,7 @@ function asy1(n::Int, a::Float64, b::Float64, nbdy)
     # First half (x > 0):
     t = tt[tt .<= pi/2]'
     mint = t[end-nbdy+1]
-    idx = 1:max(findfirst(float64(t .< mint))-1, 1)
+    idx = 1:max(findfirst(t .< mint)-1, 1)
 
     dt = 1.0; counter = 0
     # Newton iteration
@@ -149,7 +149,7 @@ function asy1(n::Int, a::Float64, b::Float64, nbdy)
     tmp = a; a = b; b = tmp
     t = pi - tt[1:(n-length(x))]'
     mint = t[nbdy]
-    idx = max(findfirst(float64(t .> mint)), 1):length(t)
+    idx = max(findfirst(t .> mint), 1):length(t)
 
     dt = 1.0; counter = 0;
     # Newton iteration
@@ -349,7 +349,7 @@ function besselRoots(nu::Float64, m::Int)
         nu1 = nu + 1;
         # See Piessens 1984:
         xs = 2*sqrt(nu+1)*(1 + nu1/4 - 7*nu1^2/96 + 49*nu1^3/1152 - 8363*nu1/276480);
-        m1 = min(max(2*ceil(abs(log10(nu1))), 3), m);
+        m1 = floor(Int, min(max(2*ceil(abs(log10(nu1))), 3), m));
     end
 
     jk[1] = besselNewton(nu, xs);

--- a/src/gaussjacobi.jl
+++ b/src/gaussjacobi.jl
@@ -1,4 +1,4 @@
-function gaussjacobi(n::Int64, a, b)
+function gaussjacobi(n::Int, a, b)
 #GAUSS-JACOBI QUADRATURE NODES AND WEIGHTS
 
     if ( a == 0 && b == 0 )
@@ -19,17 +19,17 @@ function gaussjacobi(n::Int64, a, b)
         x = JacobiRec(n, a, b)
     elseif ( n > 100 )
         x = JacobiAsy(n, a, b)
-    else 
+    else
         error("1st argument must be a positive integer.")
     end
     return x
 end
 
 
-function JacobiRec(n::Int64, a::Float64, b::Float64)
+function JacobiRec(n::Int, a::Float64, b::Float64)
 #Compute nodes and weights using recurrrence relation.
     x1 = HalfRec(n, a, b, 1)
-    x2 = HalfRec(n, b, a, 0) 
+    x2 = HalfRec(n, b, a, 0)
     x = vcat( -flipud(x2[1]) , x1[1] )
     ders = vcat( flipud(x2[2]) , x1[2] )
     w = 1./((1-x.^2).*ders.^2)
@@ -37,31 +37,31 @@ function JacobiRec(n::Int64, a::Float64, b::Float64)
     return x, w
 end
 
-function HalfRec(n::Int64, a::Float64, b::Float64, flag)
+function HalfRec(n::Int, a::Float64, b::Float64, flag)
 #HALFREC   Jacobi polynomial recurrence relation.
     # Asymptotic formula - only valid for positive x.
     r = (flag==1) ? collect(ceil(n/2):-1:1) : collect(floor(n/2):-1:1)
     C = (2*r+a-.5)*pi/(2*n+a+b+1)
     x = cos( C + 1/(2*n+a+b+1)^2 * ((.25-a^2)*cot(.5*C) - (.25-b^2)*tan(.5*C)) )
-    dx = 1.0 
+    dx = 1.0
     counter = 0
     # Loop until convergence:
     while ( norm(dx,Inf) > sqrt(eps(Float64))/1000 && counter < 10 )
         counter = counter + 1
         P = innerJacobiRec(n, x, a, b)
-        dx = -P[1]./P[2] 
+        dx = -P[1]./P[2]
         x += dx
     end
     # Once more for derivatives:
-    P = innerJacobiRec(n, x, a, b)     
+    P = innerJacobiRec(n, x, a, b)
     return x, P[2]
 end
 
-function innerJacobiRec(n::Int64, x::Array{Float64}, a::Float64, b::Float64)
+function innerJacobiRec(n::Int, x::Array{Float64}, a::Float64, b::Float64)
 # EVALUATE JACOBI POLYNOMIALS AND ITS DERIVATIVE USING THREE-TERM RECURRENCE.
     #P, Pm1, PP, PPm1 = [.5*(a-b+(a+b+2)*x)], ones(x), .5*(a+b+2)*ones(x), zeros(x)
     N = length(x)
-    P = Array(Float64,N); Pm1 = Array(Float64,N); PP = Array(Float64,N); PPm1 = Array(Float64,N); 
+    P = Array(Float64,N); Pm1 = Array(Float64,N); PP = Array(Float64,N); PPm1 = Array(Float64,N);
     for j = 1:N
         P[j] = .5*(a-b+(a+b+2)*x[j]); Pm1[j] = 1.0; PP[j] = .5*(a+b+2); PPm1[j] = 0.0
         for k = 1:n-1
@@ -76,10 +76,10 @@ function innerJacobiRec(n::Int64, x::Array{Float64}, a::Float64, b::Float64)
     return P, PP
 end
 
-function weightsConstant( n::Int64, a::Float64, b::Float64 )
+function weightsConstant( n::Int, a::Float64, b::Float64 )
     # Compute the constant for weights:
     M = min(20, n-1)
-    C = 1.0 
+    C = 1.0
     p::Float64 = -a*b/n
     for m = 1:M
         C += p
@@ -89,7 +89,7 @@ function weightsConstant( n::Int64, a::Float64, b::Float64 )
     return 2^(a+b+1)*C
 end
 
-function JacobiAsy(n::Int64, a::Float64, b::Float64)
+function JacobiAsy(n::Int, a::Float64, b::Float64)
 #ASY   Compute nodes and weights using asymptotic formulae.
 
     # Determine switch between interior and boundary regions:
@@ -98,26 +98,26 @@ function JacobiAsy(n::Int64, a::Float64, b::Float64)
     bdyidx2 = nbdy:-1:1
 
     # Interior formula:
-    x = asy1(n, a, b, nbdy) 
+    x = asy1(n, a, b, nbdy)
     w = x[2]; x = x[1]
 
     # Boundary formula (right):
-    xbdy = boundary(n, a, b, nbdy);  
+    xbdy = boundary(n, a, b, nbdy);
     x[bdyidx1] = xbdy[1]
     w[bdyidx1] = xbdy[2]
-    
+
     # Boundary formula (left):
     if ( !(a == b) )
-        xbdy = boundary(n, b, a, nbdy)  
+        xbdy = boundary(n, b, a, nbdy)
     end
-    x[bdyidx2] = -xbdy[1] 
+    x[bdyidx2] = -xbdy[1]
     w[bdyidx2] = xbdy[2]
-    
+
     w *= weightsConstant(n, a, b)
     return x[:], w[:]
 end
 
-function asy1(n::Int64, a::Float64, b::Float64, nbdy)
+function asy1(n::Int, a::Float64, b::Float64, nbdy)
 # Algorithm for computing nodes and weights in the interior.
 
     # Approximate roots via asymptotic formula: (Gatteschi and Pittaluga, 1985)
@@ -169,9 +169,9 @@ function asy1(n::Int64, a::Float64, b::Float64, nbdy)
     return x, w
 end
 
-function feval_asy1(n::Int64, a::Float64, b::Float64, t, idx, flag)
+function feval_asy1(n::Int, a::Float64, b::Float64, t, idx, flag)
 # Evaluate the interior asymptotic formula at x = cos(t).
-    
+
     # Number of terms in the expansion:
     M = 20
 
@@ -184,7 +184,7 @@ function feval_asy1(n::Int64, a::Float64, b::Float64, t, idx, flag)
 
     if ( flag == 1 )
         k = ( idx[1] == 1 ) ? collect(length(t):-1:1)' : collect(1:length(t))'
-        ta = float64(float32(t)) 
+        ta = float64(float32(t))
         tb = t - ta; hi = n*ta; lo = n*tb + (a+b+1)*.5*t
         pia = float64(float32(pi))
         pib = -8.742278000372485e-08; #pib = pi - pia
@@ -274,7 +274,7 @@ function feval_asy1(n::Int64, a::Float64, b::Float64, t, idx, flag)
         s = s + ds
     end
     p2 = exp(s)*sqrt(2*pi)*sqrt((n+a)*(n+b)/(2*n+a+b))/(2*n+a+b+1)
-    g = [1, 1/12, 1/288, -139/51840, -571/2488320, 163879/209018880, 
+    g = [1, 1/12, 1/288, -139/51840, -571/2488320, 163879/209018880,
          5246819/75246796800, -534703531/902961561600,
          -4483131259/86684309913600, 432261921612371/514904800886784000]
     f(g,z) = sum(g.*[1;cumprod(ones(9)./z)])
@@ -289,11 +289,11 @@ function feval_asy1(n::Int64, a::Float64, b::Float64, t, idx, flag)
     denom = 1./real(sin(t/2).^(a+.5).*cos(t/2).^(b+.5))
     vals = vals.*denom
     ders = ders.*denom
-     
+
     return (vals, ders)
 end
 
-function boundary(n::Int64, a::Float64, b::Float64, npts)
+function boundary(n::Int, a::Float64, b::Float64, npts)
 # Algorithm for computing nodes and weights near the boundary.
 
     # Use Newton iterations to find the first few Bessel roots:
@@ -303,7 +303,7 @@ function boundary(n::Int64, a::Float64, b::Float64, npts)
     if ( npts > smallK )
         mu = 4*a^2;
         a8 = 8*([length(jk)+1:npts]'+.5*a-.25)*pi
-        jk2 = .125*a8-(mu-1)./a8 - 4*(mu-1)*(7*mu-31)/3./a8.^3 - 
+        jk2 = .125*a8-(mu-1)./a8 - 4*(mu-1)*(7*mu-31)/3./a8.^3 -
           32*(mu-1)*(83*mu.^2-983*mu+3779)/15./a8.^5 -
           64*(mu-1)*(6949*mu^3-153855*mu^2+1585743*mu-6277237)/105./a8.^7
         jk = [jk ; jk2]
@@ -324,22 +324,22 @@ function boundary(n::Int64, a::Float64, b::Float64, npts)
     end
     vals = innerJacobiRec(n, x, a, b);     # Evaluate via asymptotic formula.
     dx = -vals[1]./vals[2]                        # Newton update
-    x += dx    
-    
+    x += dx
+
     # flip:
     x = x[npts:-1:1]
     ders = vals[2]; vals = vals[1]
     ders = ders[npts:-1:1]
 
-    # Revert to x-space:     
+    # Revert to x-space:
     w = 1./((1-x.^2).*ders.^2)
     return x, w
 end
 
-function besselRoots(nu::Float64, m::Int64)
+function besselRoots(nu::Float64, m::Int)
 # BESSELROOTS(NU, M) returns the first M roots of besselj(nu, x).
 # Find an approximation:
-    jk = Array(Float64, m) 
+    jk = Array(Float64, m)
     m1 = 3
     if ( nu == 0 )
         xs = 2.404825557695773
@@ -377,6 +377,6 @@ function besselNewton(nu::Float64, x::Float64)
         dx = u./du
         x -= dx
         counter += 1
-    end  
+    end
     return x
 end

--- a/src/gausslegendre.jl
+++ b/src/gausslegendre.jl
@@ -1,9 +1,9 @@
-function gausslegendre( n::Int64 )
+function gausslegendre( n::Int )
 # GAUSSLEGENDRE(n)  COMPUTE THE GAUSS-LEGENDRE NODES AND WEIGHTS IN O(n) time.
 
 if n < 0
     x = (Float64[],Float64[])
-elseif n == 0 
+elseif n == 0
     x = (Float64[],Float64[])
 elseif n == 1
     x = ([0.0],[2.0])
@@ -12,20 +12,20 @@ elseif n == 2
     w = Array(Float64,2)
     x[1] = -1/sqrt(3)
     x[2] = 1/sqrt(3)
-    w[1] = 1.0 
+    w[1] = 1.0
     w[2] =  1.0
     x = (x,w)
 elseif n == 3
     x = Array(Float64,3)
     w = Array(Float64,3)
-    x[1] = -sqrt(3/5) 
+    x[1] = -sqrt(3/5)
     x[2] = 0.0
-    x[3] = sqrt(3/5) 
+    x[3] = sqrt(3/5)
     w[1] = 5/9
     w[2] = 8/9
     w[3] = 5/9
     x = (x,w)
-elseif n == 4 
+elseif n == 4
     x = Array(Float64,4)
     w = Array(Float64,4)
     const a::Float64 = 2/7*sqrt(6/5)
@@ -42,10 +42,10 @@ elseif n == 5
     x = Array(Float64, 5)
     w = Array(Float64, 5)
     const b::Float64 = 2sqrt(10/7)
-    x[1] = -sqrt(5+b)/3 
+    x[1] = -sqrt(5+b)/3
     x[2] = -sqrt(5-b)/3
     x[3] = 0.0
-    x[4] = sqrt(5-b)/3 
+    x[4] = sqrt(5-b)/3
     x[5] = sqrt(5+b)/3
     w[1] = (322-13sqrt(70))/900
     w[2] = (322+13sqrt(70))/900
@@ -53,23 +53,23 @@ elseif n == 5
     w[4] = (322+13sqrt(70))/900
     w[5] = (322-13sqrt(70))/900
     x = (x, w);
-elseif n <= 60 
-# NEWTON'S METHOD WITH THREE-TERM RECURRENCE:   
-    x = rec( n::Int64 )
+elseif n <= 60
+# NEWTON'S METHOD WITH THREE-TERM RECURRENCE:
+    x = rec( n::Int )
 else
 # USE ASYMPTOTIC EXPANSIONS:
-    x = asy( n::Int64 )
+    x = asy( n::Int )
 end
-    return x   # nodes and weights in tuple. 
+    return x   # nodes and weights in tuple.
 end
 
-function asy( n::Int64 )
-# COMPUTE GAUSS-LEGENDRE NODES AND WEIGHTS USING ASYMPTOTIC EXPANSIONS. COMPLEXITY O(n). 
+function asy( n::Int )
+# COMPUTE GAUSS-LEGENDRE NODES AND WEIGHTS USING ASYMPTOTIC EXPANSIONS. COMPLEXITY O(n).
     # Nodes and weights:
     m = (mod(n,2)==0) ? n>>1 : (n+1)>>1
     a = besselZeroRoots(m)
     scale!(a,1/(n + 0.5))
-    x = legpts_nodes(n, a); 
+    x = legpts_nodes(n, a);
     w = legpts_weights(n, m, a)
     # Use symmetry to get the others:
     if ( mod(n, 2) == 1 )
@@ -82,7 +82,7 @@ function asy( n::Int64 )
     return x, w
 end
 
-function legpts_nodes(n::Int64, a::Array{Float64})
+function legpts_nodes(n::Int, a::Array{Float64})
 # ASYMPTOTIC EXPANSION FOR THE GAUSS-LEGENDRE NODES.
     vn = 1/(n + 0.5)
     m = length(a)
@@ -96,7 +96,7 @@ function legpts_nodes(n::Int64, a::Array{Float64})
     return nodes
 end
 
-function legpts_weights(n::Int64, m::Int64, a::Array{Float64})
+function legpts_weights(n::Int, m::Int, a::Array{Float64})
 # ASYMPTOTIC EXPANSION FOR THE GAUSS-LEGENDRE WEIGHTS.
     vn = 1/(n + 0.5);
     u = Array(Float64,m); ua = Array(Float64,m); weights = Array(Float64,m)
@@ -118,27 +118,27 @@ function legpts_weights(n::Int64, m::Int64, a::Array{Float64})
     return weights
 end
 
-function rec( n::Int64 ) 
-# COMPUTE GAUSS-LEGENDRE NODES AND WEIGHTS USING NEWTON'S METHOD. THREE-TERM RECURENCE 
-# IS USED FOR EVALUATION. COMPLEXITY O(n^2). 
+function rec( n::Int )
+# COMPUTE GAUSS-LEGENDRE NODES AND WEIGHTS USING NEWTON'S METHOD. THREE-TERM RECURENCE
+# IS USED FOR EVALUATION. COMPLEXITY O(n^2).
     hN = mod(n,2)
-    # Initial guesses: 
-    x0 = asy(n)[1]; x = x0[(n-hN)/2+1:n]   
+    # Initial guesses:
+    x0 = asy(n)[1]; x = x0[(n-hN)/2+1:n]
     # Perform Newton to find zeros of Legendre polynomial:
     PP = innerRec( n, x ); dx = -PP[1]./PP[2]; x += dx
-    # One more Newton for derivatives: 
+    # One more Newton for derivatives:
     PP = innerRec( n, x ); dx = -PP[1]./PP[2]; x += dx
     #PP = (n<45)? innerRec( n, x ) : PP
-    # Use symmetry to get the other Legendre nodes and weights: 
+    # Use symmetry to get the other Legendre nodes and weights:
     nodes = vcat( -x[(n+hN)/2:-1:hN+1] , x )
     weights = 2./((1-nodes.^2).*vcat( PP[2][(n+hN)/2:-1:1+hN] , PP[2] ).^2)
     return nodes, weights
 end
 
-function innerRec( n::Int64, x )
+function innerRec( n::Int, x )
 # EVALUATE LEGENDRE AND ITS DERIVATIVE USING THREE-TERM RECURRENCE RELATION.
-    N = size(x,1) 
-    myPm1 = Array(Float64,N); myPPm1 = Array(Float64,N) 
+    N = size(x,1)
+    myPm1 = Array(Float64,N); myPPm1 = Array(Float64,N)
     for j = 1:N
         xj = x[j]; Pm2 = 1.0; Pm1 = xj; PPm1 = 1.0; PPm2 = 0.0
         for k = 1:n-1
@@ -146,13 +146,13 @@ function innerRec( n::Int64, x )
             PPm2, PPm1 = PPm1, ((2k+1)*(Pm2 + xj*PPm1)-k*PPm2)/(k+1)
         end
         myPm1[j] = Pm1
-        myPPm1[j] = PPm1 
+        myPPm1[j] = PPm1
     end
     return myPm1, myPPm1
 end
 
 
-function besselZeroRoots(m::Int64)
+function besselZeroRoots(m::Int)
 #BESSEL0ROOTS ROOTS OF BESSELJ(0,x). USE ASYMPTOTICS.
 # Use McMahon's expansion for the remainder (NIST, 10.21.19):
     jk = Array(Float64,m); ak = Array(Float64,m); ak82 = Array(Float64,m)
@@ -176,7 +176,7 @@ function besselZeroRoots(m::Int64)
 end
 
 
-function besselJ1( m::Int64 )
+function besselJ1( m::Int )
 # BESSELJ1 EVALUATE BESSELJ(1,x)^2 AT ROOTS OF BESSELJ(0,x). USE ASYMPTOTICS.
 # Use Taylor series of (NIST, 10.17.3) and McMahon's expansion (NIST, 10.21.19):
     Jk2 = Array(Float64,m); ak = Array(Float64,m); ak2 = Array(Float64,m)
@@ -188,7 +188,7 @@ function besselJ1( m::Int64 )
             0.05403757319811628, 0.04266142901724309, 0.03524210349099610,
             0.03002107010305467, 0.02614739149530809, 0.02315912182469139, 0.02078382912226786]
     for jj=1:min(m,10) Jk2[jj] = ten[jj] end
-    for jj=11:min(m,15) Jk2[jj] = 1/(pi*ak[jj])*(c[7] + ak2[jj]^2*(c[5] + ak2[jj]*(c[4] + 
+    for jj=11:min(m,15) Jk2[jj] = 1/(pi*ak[jj])*(c[7] + ak2[jj]^2*(c[5] + ak2[jj]*(c[4] +
                 ak2[jj]*(c[3] + ak2[jj]*(c[2]+ak2[jj]*c[1]))))) end
     for jj=16:min(m,21) Jk2[jj] = 1/(pi*ak[jj])*(c[7] + ak2[jj]^2*(c[5] + ak2[jj]*(c[4] + ak2[jj]*(c[3] + ak2[jj]*c[2])))) end
     for jj=22:min(m,55) Jk2[jj] =  1/(pi*ak[jj])*(c[7] + ak2[jj]^2*(c[5] + ak2[jj]*(c[4] + ak2[jj]*c[3]))) end

--- a/src/gausslegendre.jl
+++ b/src/gausslegendre.jl
@@ -123,15 +123,15 @@ function rec( n::Int )
 # IS USED FOR EVALUATION. COMPLEXITY O(n^2).
     hN = mod(n,2)
     # Initial guesses:
-    x0 = asy(n)[1]; x = x0[(n-hN)/2+1:n]
+    x0 = asy(n)[1]; x = x0[div(n-hN,2)+1:n]
     # Perform Newton to find zeros of Legendre polynomial:
     PP = innerRec( n, x ); dx = -PP[1]./PP[2]; x += dx
     # One more Newton for derivatives:
     PP = innerRec( n, x ); dx = -PP[1]./PP[2]; x += dx
     #PP = (n<45)? innerRec( n, x ) : PP
     # Use symmetry to get the other Legendre nodes and weights:
-    nodes = vcat( -x[(n+hN)/2:-1:hN+1] , x )
-    weights = 2./((1-nodes.^2).*vcat( PP[2][(n+hN)/2:-1:1+hN] , PP[2] ).^2)
+    nodes = vcat( -x[div(n+hN,2):-1:hN+1] , x )
+    weights = 2./((1-nodes.^2).*vcat( PP[2][div(n+hN,2):-1:1+hN] , PP[2] ).^2)
     return nodes, weights
 end
 

--- a/src/gaussradau.jl
+++ b/src/gaussradau.jl
@@ -1,4 +1,4 @@
-function gaussradau( n::Int64 )
+function gaussradau( n::Int )
 #RADAUPTS   Gauss-Legendre-Radau Quadrature Nodes and Weights
 
     if ( n == 1 )


### PR DESCRIPTION
This changes Int64 -> Int so that the package can easily be used on 32 bit architectures.

It also removes some deprecation warnings for 0.4.

Also some trailing whitespace removal.