### PR TITLE
Removed weight normalization in Golub-Welsch for gaussjacobi

### DIFF
--- a/src/gaussjacobi.jl
+++ b/src/gaussjacobi.jl
@@ -383,6 +383,5 @@ function JacobiGW( n::Integer, a::Float64, b::Float64 )
     x, V = eigen( TT )                       # Eigenvalue decomposition.
     # Quadrature weights:
     w = V[1,:].^2 .*( 2^(ab+1)*gamma(a+1)*gamma(b+1)/gamma(2+ab) );
-    w .= w./sum(w);
     x, vec(w)
 end

--- a/test/test_gaussjacobi.jl
+++ b/test/test_gaussjacobi.jl
@@ -56,7 +56,7 @@ x, w = gaussjacobi(10013, .9, -.1)
 # test last alpha and beta parameters:
 x, w = gaussjacobi(100, 19., 21.)
 @test abs(x[87] - 0.832211446176040) < tol
-@test abs(w[50] - 0.064530500882703) < tol
+@test abs(w[50] - 0.026363584978877305) < tol # new test without condition sum(w)==1
 
 # test for small alpha and beta:
 x, w = gaussjacobi(10000, .1, .2)


### PR DESCRIPTION
The Golub Welsch algorithm for gaussjacobi previously returned weights normalized such that the weights summed to one. This need not be true in general.

[See discussion here](https://github.com/ajt60gaibb/FastGaussQuadrature.jl/issues/65)