### PR TITLE
Besselroots for larger nu

### DIFF
--- a/src/besselroots.jl
+++ b/src/besselroots.jl
@@ -33,10 +33,13 @@ function besselroots(nu::Float64, n::Integer)
         for k in min(n,6)+1:n
             x[k] = McMahon(nu, k)
         end
+    elseif nu > 5
+        for k in 1:n
+            x[k] = McMahon(nu, k)
+        end
     end
     x
 end
-
 
 function McMahon(nu::Float64, k::Integer)
     # McMahon's expansion. This expansion gives very accurate approximation


### PR DESCRIPTION
The `besselroots` function claims it evaluates the McMahon expansion for nu larger than 5, but just returns zeros.

This pull request simply evaluates the McMahon expansion for nu > 5. One could argue whether it is safer to return zeros rather than inaccurate values. Perhaps it is even safer to emit a warning.
